### PR TITLE
Open in new window toggler

### DIFF
--- a/block.json
+++ b/block.json
@@ -48,6 +48,10 @@
 		"mediaPosition": {
 			"type": "string",
 			"default": "right"
+		},
+		"target": {
+			"type": "string",
+			"default": "_blank"
 		}
 	},
 	"supports": {

--- a/src/edit.js
+++ b/src/edit.js
@@ -20,7 +20,7 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { getAuthority } from '@wordpress/url';
-import { pencil, pullLeft, pullRight } from '@wordpress/icons';
+import { customLink, pencil, pullLeft, pullRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -35,7 +35,7 @@ export default function Edit({
 	isSelected,
 	setAttributes,
 }) {
-	const { url, image, title, description, icon, publisher, mediaPosition } =
+	const { url, image, title, description, icon, publisher, mediaPosition, target } =
 		attributes;
 
 	const [fetchUrl, setFetchUrl] = useState(url);
@@ -138,6 +138,12 @@ export default function Edit({
 					title={__('Show media on right', 'bookmark-card')}
 					isActive={mediaPosition === 'right'}
 					onClick={() => setAttributes({ mediaPosition: 'right' })}
+				/>
+				<ToolbarButton
+				 icon={customLink}
+				 title={__('Open in new window', 'bookmark-card')}
+				 isActive={target === '_blank'}
+				 onClick={() => setAttributes({ target: target === '_blank' ? '_self' : '_blank' })}
 				/>
 			</BlockControls>
 			<figure {...blockProps}>

--- a/src/save.js
+++ b/src/save.js
@@ -5,11 +5,11 @@
 import { useBlockProps } from '@wordpress/block-editor';
 
 export default function save({ attributes }) {
-	const { url, image, title, description, icon, publisher } = attributes;
+	const { url, image, title, description, icon, publisher, target } = attributes;
 
 	return (
 		<figure {...useBlockProps.save()}>
-			<a className="bookmark-card" href={url}>
+			<a className="bookmark-card" href={url} target={target} rel="noopener noreferrer">
 				{image && (
 					<div className="bookmark-card__image">
 						<img src={image} />


### PR DESCRIPTION
I know this is much simpler than your [working version](https://github.com/Mamaduka/bookmark-card/commit/5c5e89acbdf87176dd6ade8d18e7660108b04e57), but does seem to work without turning the block into an image for me. Perhaps you could retry your links branch and see if it's working with latest wordpress? This is my first foray into blocks. Been out of WP for years and got sniped. 😅