### PR TITLE
Fix accessibility and other issues detected by PageSpeed

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -181,7 +181,10 @@ export default function Edit({ attributes, isSelected, setAttributes }) {
 				<a className="bookmark-card" href={url}>
 					{image && (
 						<div className="bookmark-card__image">
-							<img src={image} />
+							<img 
+								src={image} 
+								alt="Bookmark Featured Image"
+							/>
 						</div>
 					)}
 					<div className="bookmark-card__content">
@@ -194,6 +197,9 @@ export default function Edit({ attributes, isSelected, setAttributes }) {
 								<img
 									className="bookmark_card__meta-icon"
 									src={icon}
+									alt="Bookmark Favicon"
+									width="512"
+									height="512"
 								/>
 							)}
 							<span className="bookmark_card__meta-publisher">


### PR DESCRIPTION
Add alt attributes to the image and icon to fix accessibility issues. https://raw.githubusercontent.com/dscharalampidis/screenshots/1c264c5e98484fa09d3755d415af996e523a2ff9/bookmark-card/accessibility.png

Add width and height attributes to the icon to fix performance issues. https://raw.githubusercontent.com/dscharalampidis/screenshots/1c264c5e98484fa09d3755d415af996e523a2ff9/bookmark-card/performance.png

The text is generic, but please feel free to change it. The default favicon size for WordPress is 512x512, hence my choice.